### PR TITLE
Add UV index and PoP% to Gadgetbridge intent

### DIFF
--- a/app/src/main/java/com/ominous/quickweather/api/Gadgetbridge.java
+++ b/app/src/main/java/com/ominous/quickweather/api/Gadgetbridge.java
@@ -50,6 +50,8 @@ public class Gadgetbridge {
             weatherJson.put("currentHumidity", weatherResponseOneCall.current.humidity);
             weatherJson.put("windSpeed", weatherResponseOneCall.current.wind_speed);
             weatherJson.put("windDirection", weatherResponseOneCall.current.wind_deg);
+            weatherJson.put("uvIndex", weatherResponseOneCall.current.uvi);
+            weatherJson.put("precipProbability", Math.round(weatherResponseOneCall.daily[0].pop * 100));
 
             JSONArray weatherForecasts = new JSONArray();
 
@@ -60,6 +62,8 @@ public class Gadgetbridge {
                 dailyJsonData.put("humidity", weatherResponseOneCall.daily[i].humidity);
                 dailyJsonData.put("maxTemp", convertTemperatureToKelvin(weatherResponseOneCall.daily[i].temp.max));
                 dailyJsonData.put("minTemp", convertTemperatureToKelvin(weatherResponseOneCall.daily[i].temp.min));
+                dailyJsonData.put("uvIndex", weatherResponseOneCall.daily[i].uvi);
+                dailyJsonData.put("precipProbability", Math.round(weatherResponseOneCall.daily[i].pop * 100));
 
                 weatherForecasts.put(dailyJsonData);
             }


### PR DESCRIPTION
I'd like to request this change in QuickWeather, so Gadgetbridge users can view the UV index and % probability of precipitation on their devices (currently only Fossil/Skagen hybrids, but more coming soon).