### PR TITLE
Fix Gadgetbridge hourly data

### DIFF
--- a/app/src/main/java/com/ominous/quickweather/api/Gadgetbridge.java
+++ b/app/src/main/java/com/ominous/quickweather/api/Gadgetbridge.java
@@ -100,7 +100,7 @@ public class Gadgetbridge {
 
             JSONArray hourlyForecasts = new JSONArray();
 
-            for (int i = 1; i < currentWeather.daily.length; i++) {
+            for (int i = 1; i < currentWeather.hourly.length; i++) {
                 JSONObject hourlyJsonData = new JSONObject();
 
                 hourlyJsonData.put("timestamp", currentWeather.hourly[i].dt);


### PR DESCRIPTION
Missed this in the original tests, since I only cross-checked the first couple of values in the debug window, and my watch somehow interpolates or caches all the hourly values..