### PR TITLE
Bugfix: Mapbox playback speed increases when pressing play, due to not pausing properly #106

### DIFF
--- a/app/src/main/java/com/ominous/quickweather/view/WeatherMapView.java
+++ b/app/src/main/java/com/ominous/quickweather/view/WeatherMapView.java
@@ -273,6 +273,9 @@ public class WeatherMapView extends ConstraintLayout implements View.OnClickList
 
             @Override
             public void onPause() {
+                if (isPlaying) {
+                    mapView.getMapAsync(m -> playPause());
+                }
                 mapView.onPause();
             }
 


### PR DESCRIPTION
A simple fix for bug #106.

The Bug: I can make the map increase it's playback speed via a bug.
1. Tap the play button for the Mapbox
2. then tap one of the weather days that are underneath the map.
3. press back button
4. press play on the map again and it will run faster
5. repeat 5 times for super speedy map
![mapbox-speed](https://github.com/TylerWilliamson/QuickWeather/assets/43177940/19b8e306-1298-4d43-be20-5468bf239d91)
