### PR TITLE
Added a midnight divider line on the graph to visually separate days.

### DIFF
--- a/app/src/main/java/com/ominous/quickweather/card/GraphCardView.java
+++ b/app/src/main/java/com/ominous/quickweather/card/GraphCardView.java
@@ -332,6 +332,7 @@ public class GraphCardView extends BaseCardView {
         RectF graphRegion = new RectF(LEFT_PADDING, TOP_PADDING, width - RIGHT_PADDING, height - BOTTOM_PADDING - TOP_PADDING);
         RectF yAxisRegion = new RectF(0f, 0f, LEFT_PADDING, height);
         RectF xAxisRegion = new RectF(LEFT_PADDING, height - BOTTOM_PADDING, width - RIGHT_PADDING, height);
+        RectF midnightRegion = new RectF(LEFT_PADDING, height - BOTTOM_PADDING - TEXT_SIZE, width - RIGHT_PADDING, 0-height);
         RectF iconRegion = new RectF(0f, height / 2f - TEXT_SIZE / 2f - BOTTOM_PADDING / 2f, TEXT_SIZE, height / 2f + TEXT_SIZE / 2f - BOTTOM_PADDING / 2f);
 
         ArrayList<PrecipitationCurveGraphPoint> precipitationCurvePoints = getPrecipitationCurve(colorHelper, precipitationPoints, segments);
@@ -346,6 +347,10 @@ public class GraphCardView extends BaseCardView {
         graphHelper.plotLinesOnCanvas(graphRegion, strokePaint, precipitationGraphBounds, precipitationCurvePoints);
 
         graphHelper.plotPointsOnCanvas(graphRegion, fillPaint, precipitationGraphBounds, precipitationPoints);
+
+        Paint midnightDividerPaint = getStrokePaint();
+        midnightDividerPaint.setColor(ContextCompat.getColor(getContext(), R.color.text_primary_emphasis));
+        graphHelper.drawMidnightDividerOnCanvas(midnightRegion, midnightDividerPaint, temperatureGraphBounds, xGraphLabels);
 
         graphHelper.plotLinesOnCanvas(graphRegion, strokePaint, temperatureGraphBounds, temperatureCurvePoints);
 

--- a/app/src/main/java/com/ominous/quickweather/util/GraphHelper.java
+++ b/app/src/main/java/com/ominous/quickweather/util/GraphHelper.java
@@ -111,6 +111,21 @@ public class GraphHelper {
         }
     }
 
+    public void drawMidnightDividerOnCanvas(@NonNull RectF region,
+                                            @NonNull Paint paint,
+                                            @NonNull GraphBounds graphBounds,
+                                            @NonNull ArrayList<? extends IGraphLabel> points ){
+        RectF graphRegion = getGraphRect(region);
+        graphRegion.top += POINT_SIZE;
+
+        for (IGraphLabel point : points) {
+            float x = getXCoord(graphBounds, graphRegion, point.getX());
+            if( point.getLabel().trim().compareTo("00") == 0 ) {
+                canvas.drawLine(x, graphRegion.top, x, graphRegion.bottom, paint);
+            }
+        }
+    }
+
     public void drawXAxisOnCanvas(@NonNull RectF region,
                                   @NonNull Paint paint,
                                   @NonNull GraphBounds graphBounds,


### PR DESCRIPTION
I've added a little divider so we can see when we scroll to another day's forecast.

I'd like the day to be separated more. Maybe we could change the background colour for tomorrow's forecast?

**Warning: To keep the code simple, I get the hour from the label strings. If you implement AM/PM into the labels, it would break this feature.**

The midnight line will go in front of the rainfall and behind everything else, like the temperature line.
![midnight-graph2](https://github.com/TylerWilliamson/QuickWeather/assets/43177940/c50716c4-073b-4d5b-9520-79c19488204f)


![midnight-graph1](https://github.com/TylerWilliamson/QuickWeather/assets/43177940/2b7965c5-5d55-427d-ae11-e92580fd3fb6)
