### PR TITLE
Increase workers period

### DIFF
--- a/app/src/main/java/com/ominous/quickweather/work/WeatherWorkManager.java
+++ b/app/src/main/java/com/ominous/quickweather/work/WeatherWorkManager.java
@@ -39,7 +39,7 @@ public class WeatherWorkManager {
 
         if (weatherPreferences.shouldRunBackgroundJob()) {
             PeriodicWorkRequest.Builder notifRequestBuilder = new PeriodicWorkRequest
-                    .Builder(WeatherWorker.class, 15, TimeUnit.MINUTES)
+                    .Builder(WeatherWorker.class, 2, TimeUnit.HOURS)
                     .setBackoffCriteria(
                             BackoffPolicy.LINEAR,
                             3,
@@ -48,7 +48,7 @@ public class WeatherWorkManager {
 
             if (delayed) {
                 notifRequestBuilder
-                        .setInitialDelay(15, TimeUnit.MINUTES);
+                        .setInitialDelay(2, TimeUnit.HOURS);
             }
 
             workManager.enqueueUniquePeriodicWork(


### PR DESCRIPTION
Checking weather every 15 minutes is quite demanding.

I discovered it by sawing a very large amount of requests to open-meteo API.

In this PR I propose to reduce the frequency to every 2 hours.

What do you think of this time frame?

Should it be an option in the app?